### PR TITLE
text align to box

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
 				"yoga-layout-prebuilt": "1.9.6"
 			},
 			"devDependencies": {
-				"@ampproject/rollup-plugin-closure-compiler": "^0.26.0",
+				"@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
 				"@babel/core": "^7.12.16",
 				"@babel/preset-env": "^7.12.16",
 				"@babel/preset-react": "^7.12.13",
@@ -78,16 +78,16 @@
 			"dev": true
 		},
 		"node_modules/@ampproject/rollup-plugin-closure-compiler": {
-			"version": "0.26.0",
-			"resolved": "https://registry.npmjs.org/@ampproject/rollup-plugin-closure-compiler/-/rollup-plugin-closure-compiler-0.26.0.tgz",
-			"integrity": "sha512-wuHzGE6BDhDR0L7nUPlpQDPGiGnMw+b0B+cDPG0S5TatOmFNQva8KSNdBHan3L9RbvNyYXOXicuCrZtSoBfrBg==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/rollup-plugin-closure-compiler/-/rollup-plugin-closure-compiler-0.27.0.tgz",
+			"integrity": "sha512-stpAOn2ZZEJuAV39HFw9cnKJYNhEeHtcsoa83orpLDhSxsxSbVEKwHaWlFBaQYpQRSOdapC4eJhJnCzocZxnqg==",
 			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "0.2.0",
-				"acorn": "7.2.0",
+				"acorn": "7.3.1",
 				"acorn-walk": "7.1.1",
 				"estree-walker": "2.0.1",
-				"google-closure-compiler": "20200517.0.0",
+				"google-closure-compiler": "20210808.0.0",
 				"magic-string": "0.25.7",
 				"uuid": "8.1.0"
 			},
@@ -99,9 +99,9 @@
 			}
 		},
 		"node_modules/@ampproject/rollup-plugin-closure-compiler/node_modules/acorn": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-			"integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+			"integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -7460,7 +7460,7 @@
 		"node_modules/clone": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+			"integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.8"
@@ -7469,7 +7469,7 @@
 		"node_modules/clone-buffer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+			"integrity": "sha512-KLLTJWrvwIP+OPfMn0x2PheDEP20RPUcGXj/ERegTgdmPEZylALQldygiqrPPu8P45uNuPs7ckmReLY6v/iA5g==",
 			"dev": true,
 			"engines": {
 				"node": ">= 0.10"
@@ -7501,7 +7501,7 @@
 		"node_modules/clone-stats": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-			"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+			"integrity": "sha512-au6ydSpg6nsrigcZ4m8Bc9hxjeW+GJ8xh5G3BJCMt4WXe1H10UNaVOamqQTmrx1kjVuxAHIQSNU6hY4Nsn9/ag==",
 			"dev": true
 		},
 		"node_modules/cloneable-readable": {
@@ -10371,6 +10371,7 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
 			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
 			"hasInstallScript": true,
 			"optional": true,
 			"os": [
@@ -11087,14 +11088,13 @@
 			}
 		},
 		"node_modules/google-closure-compiler": {
-			"version": "20200517.0.0",
-			"resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20200517.0.0.tgz",
-			"integrity": "sha512-80W9zBS9Ajk1T5InWCfsoPohDmo5T1AAyw1rHh5+dgb/jPgwC65KhY+oJozTncf+/7tyQHJXozTARwhSlBUcMg==",
+			"version": "20210808.0.0",
+			"resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20210808.0.0.tgz",
+			"integrity": "sha512-+R2+P1tT1lEnDDGk8b+WXfyVZgWjcCK9n1mmZe8pMEzPaPWxqK7GMetLVWnqfTDJ5Q+LRspOiFBv3Is+0yuhCA==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "2.x",
-				"google-closure-compiler-java": "^20200517.0.0",
-				"google-closure-compiler-js": "^20200517.0.0",
+				"google-closure-compiler-java": "^20210808.0.0",
 				"minimist": "1.x",
 				"vinyl": "2.x",
 				"vinyl-sourcemaps-apply": "^0.2.0"
@@ -11103,30 +11103,24 @@
 				"google-closure-compiler": "cli.js"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=10"
 			},
 			"optionalDependencies": {
-				"google-closure-compiler-linux": "^20200517.0.0",
-				"google-closure-compiler-osx": "^20200517.0.0",
-				"google-closure-compiler-windows": "^20200517.0.0"
+				"google-closure-compiler-linux": "^20210808.0.0",
+				"google-closure-compiler-osx": "^20210808.0.0",
+				"google-closure-compiler-windows": "^20210808.0.0"
 			}
 		},
 		"node_modules/google-closure-compiler-java": {
-			"version": "20200517.0.0",
-			"resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20200517.0.0.tgz",
-			"integrity": "sha512-JVZBiyyXwcYi6Yc3lO6dF2hMLJA4OzPm4/mgsem/tF1vk2HsWTnL3GTaBsPB2ENVZp0hoqsd4KgpPiG9ssNWxw==",
+			"version": "20210808.0.0",
+			"resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20210808.0.0.tgz",
+			"integrity": "sha512-7dEQfBzOdwdjwa/Pq8VAypNBKyWRrOcKjnNYOO9gEg2hjh8XVMeQzTqw4uANfVvvANGdE/JjD+HF6zHVgLRwjg==",
 			"dev": true
 		},
-		"node_modules/google-closure-compiler-js": {
-			"version": "20200517.0.0",
-			"resolved": "https://registry.npmjs.org/google-closure-compiler-js/-/google-closure-compiler-js-20200517.0.0.tgz",
-			"integrity": "sha512-dz6dOUHx5nhdIqMRXacAYS8aJfLvw4IKxGg28Hq/zeeDPHlX3P3iBK20NgFDfT8zdushThymtMqChSy7C5eyfA==",
-			"dev": true
-		},
-		"node_modules/google-closure-compiler-osx": {
-			"version": "20200517.0.0",
-			"resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20200517.0.0.tgz",
-			"integrity": "sha512-FWIcsKqLllLjdOBZd7azijVaObydgRd0obVNi63eUfC5MX6T4qxKumGCyor2UCNY6by2ESz+PlGqCFzFhZ6b2g==",
+		"node_modules/google-closure-compiler-linux": {
+			"version": "20210808.0.0",
+			"resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20210808.0.0.tgz",
+			"integrity": "sha512-byKi5ITUiWRvEIcQo76i1siVnOwrTmG+GNcBG4cJ7x8IE6+4ki9rG5pUe4+DOYHkfk52XU6XHt9aAAgCcFDKpg==",
 			"cpu": [
 				"x64",
 				"x86"
@@ -11134,7 +11128,35 @@
 			"dev": true,
 			"optional": true,
 			"os": [
+				"linux"
+			]
+		},
+		"node_modules/google-closure-compiler-osx": {
+			"version": "20210808.0.0",
+			"resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20210808.0.0.tgz",
+			"integrity": "sha512-iwyAY6dGj1FrrBdmfwKXkjtTGJnqe8F+9WZbfXxiBjkWLtIsJt2dD1+q7g/sw3w8mdHrGQAdxtDZP/usMwj/Rg==",
+			"cpu": [
+				"x64",
+				"x86",
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
 				"darwin"
+			]
+		},
+		"node_modules/google-closure-compiler-windows": {
+			"version": "20210808.0.0",
+			"resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20210808.0.0.tgz",
+			"integrity": "sha512-VI+UUYwtGWDYwpiixrWRD8EklHgl6PMbiEaHxQSrQbH8PDXytwaOKqmsaH2lWYd5Y/BOZie2MzjY7F5JI69q1w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
 			]
 		},
 		"node_modules/gopd": {
@@ -11626,9 +11648,9 @@
 			}
 		},
 		"node_modules/immutable": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
-			"integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA=="
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
+			"integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw=="
 		},
 		"node_modules/import-cwd": {
 			"version": "3.0.0",
@@ -17087,6 +17109,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
 			"engines": {
 				"node": ">=8.6"
 			},
@@ -21026,11 +21049,11 @@
 			}
 		},
 		"node_modules/sass": {
-			"version": "1.69.0",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.69.0.tgz",
-			"integrity": "sha512-l3bbFpfTOGgQZCLU/gvm1lbsQ5mC/WnLz3djL2v4WCJBDrWm58PO+jgngcGRNnKUh6wSsdm50YaovTqskZ0xDQ==",
+			"version": "1.79.4",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.79.4.tgz",
+			"integrity": "sha512-K0QDSNPXgyqO4GZq2HO5Q70TLxTH6cIT59RdoCHMivrC8rqzaTw5ab9prjz9KUN1El4FLXrBXJhik61JR4HcGg==",
 			"dependencies": {
-				"chokidar": ">=3.0.0 <4.0.0",
+				"chokidar": "^4.0.0",
 				"immutable": "^4.0.0",
 				"source-map-js": ">=0.6.2 <2.0.0"
 			},
@@ -21041,151 +21064,30 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/sass/node_modules/anymatch": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-			"dependencies": {
-				"normalize-path": "^3.0.0",
-				"picomatch": "^2.0.4"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/sass/node_modules/binary-extensions": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/sass/node_modules/braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-			"dependencies": {
-				"fill-range": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/sass/node_modules/chokidar": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-			"integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://paulmillr.com/funding/"
-				}
-			],
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+			"integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
 			"dependencies": {
-				"anymatch": "~3.1.2",
-				"braces": "~3.0.2",
-				"glob-parent": "~5.1.2",
-				"is-binary-path": "~2.1.0",
-				"is-glob": "~4.0.1",
-				"normalize-path": "~3.0.0",
-				"readdirp": "~3.6.0"
+				"readdirp": "^4.0.1"
 			},
 			"engines": {
-				"node": ">= 8.10.0"
+				"node": ">= 14.16.0"
 			},
-			"optionalDependencies": {
-				"fsevents": "~2.3.2"
-			}
-		},
-		"node_modules/sass/node_modules/fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-			"dependencies": {
-				"to-regex-range": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/sass/node_modules/glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"dependencies": {
-				"is-glob": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/sass/node_modules/is-binary-path": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-			"dependencies": {
-				"binary-extensions": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/sass/node_modules/is-extglob": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/sass/node_modules/is-glob": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-			"dependencies": {
-				"is-extglob": "^2.1.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/sass/node_modules/is-number": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"engines": {
-				"node": ">=0.12.0"
-			}
-		},
-		"node_modules/sass/node_modules/normalize-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"engines": {
-				"node": ">=0.10.0"
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/sass/node_modules/readdirp": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-			"dependencies": {
-				"picomatch": "^2.2.1"
-			},
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
+			"integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
 			"engines": {
-				"node": ">=8.10.0"
-			}
-		},
-		"node_modules/sass/node_modules/to-regex-range": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dependencies": {
-				"is-number": "^7.0.0"
+				"node": ">= 14.16.0"
 			},
-			"engines": {
-				"node": ">=8.0"
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/sax": {
@@ -21611,9 +21513,9 @@
 			}
 		},
 		"node_modules/source-map-js": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -23030,9 +22932,9 @@
 			}
 		},
 		"node_modules/vinyl": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-			"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
+			"integrity": "sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==",
 			"dev": true,
 			"dependencies": {
 				"clone": "^2.1.1",
@@ -23049,7 +22951,7 @@
 		"node_modules/vinyl-sourcemaps-apply": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
-			"integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+			"integrity": "sha512-+oDh3KYZBoZC8hfocrbrxbLUeaYtQK7J5WU5Br9VqWqmCll3tFJqKp97GC9GmMsVIL0qnx2DgEDVxdo5EZ5sSw==",
 			"dev": true,
 			"dependencies": {
 				"source-map": "^0.5.1"
@@ -23591,24 +23493,24 @@
 			}
 		},
 		"@ampproject/rollup-plugin-closure-compiler": {
-			"version": "0.26.0",
-			"resolved": "https://registry.npmjs.org/@ampproject/rollup-plugin-closure-compiler/-/rollup-plugin-closure-compiler-0.26.0.tgz",
-			"integrity": "sha512-wuHzGE6BDhDR0L7nUPlpQDPGiGnMw+b0B+cDPG0S5TatOmFNQva8KSNdBHan3L9RbvNyYXOXicuCrZtSoBfrBg==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/rollup-plugin-closure-compiler/-/rollup-plugin-closure-compiler-0.27.0.tgz",
+			"integrity": "sha512-stpAOn2ZZEJuAV39HFw9cnKJYNhEeHtcsoa83orpLDhSxsxSbVEKwHaWlFBaQYpQRSOdapC4eJhJnCzocZxnqg==",
 			"dev": true,
 			"requires": {
 				"@ampproject/remapping": "0.2.0",
-				"acorn": "7.2.0",
+				"acorn": "7.3.1",
 				"acorn-walk": "7.1.1",
 				"estree-walker": "2.0.1",
-				"google-closure-compiler": "20200517.0.0",
+				"google-closure-compiler": "20210808.0.0",
 				"magic-string": "0.25.7",
 				"uuid": "8.1.0"
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-					"integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+					"integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
 					"dev": true
 				},
 				"estree-walker": {
@@ -29420,13 +29322,13 @@
 		"clone": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+			"integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
 			"dev": true
 		},
 		"clone-buffer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+			"integrity": "sha512-KLLTJWrvwIP+OPfMn0x2PheDEP20RPUcGXj/ERegTgdmPEZylALQldygiqrPPu8P45uNuPs7ckmReLY6v/iA5g==",
 			"dev": true
 		},
 		"clone-deep": {
@@ -29451,7 +29353,7 @@
 		"clone-stats": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-			"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+			"integrity": "sha512-au6ydSpg6nsrigcZ4m8Bc9hxjeW+GJ8xh5G3BJCMt4WXe1H10UNaVOamqQTmrx1kjVuxAHIQSNU6hY4Nsn9/ag==",
 			"dev": true
 		},
 		"cloneable-readable": {
@@ -31685,6 +31587,7 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
 			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
 			"optional": true
 		},
 		"function-bind": {
@@ -32236,38 +32139,45 @@
 			}
 		},
 		"google-closure-compiler": {
-			"version": "20200517.0.0",
-			"resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20200517.0.0.tgz",
-			"integrity": "sha512-80W9zBS9Ajk1T5InWCfsoPohDmo5T1AAyw1rHh5+dgb/jPgwC65KhY+oJozTncf+/7tyQHJXozTARwhSlBUcMg==",
+			"version": "20210808.0.0",
+			"resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20210808.0.0.tgz",
+			"integrity": "sha512-+R2+P1tT1lEnDDGk8b+WXfyVZgWjcCK9n1mmZe8pMEzPaPWxqK7GMetLVWnqfTDJ5Q+LRspOiFBv3Is+0yuhCA==",
 			"dev": true,
 			"requires": {
 				"chalk": "2.x",
-				"google-closure-compiler-java": "^20200517.0.0",
-				"google-closure-compiler-js": "^20200517.0.0",
-				"google-closure-compiler-linux": "^20200517.0.0",
-				"google-closure-compiler-osx": "^20200517.0.0",
-				"google-closure-compiler-windows": "^20200517.0.0",
+				"google-closure-compiler-java": "^20210808.0.0",
+				"google-closure-compiler-linux": "^20210808.0.0",
+				"google-closure-compiler-osx": "^20210808.0.0",
+				"google-closure-compiler-windows": "^20210808.0.0",
 				"minimist": "1.x",
 				"vinyl": "2.x",
 				"vinyl-sourcemaps-apply": "^0.2.0"
 			}
 		},
 		"google-closure-compiler-java": {
-			"version": "20200517.0.0",
-			"resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20200517.0.0.tgz",
-			"integrity": "sha512-JVZBiyyXwcYi6Yc3lO6dF2hMLJA4OzPm4/mgsem/tF1vk2HsWTnL3GTaBsPB2ENVZp0hoqsd4KgpPiG9ssNWxw==",
+			"version": "20210808.0.0",
+			"resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20210808.0.0.tgz",
+			"integrity": "sha512-7dEQfBzOdwdjwa/Pq8VAypNBKyWRrOcKjnNYOO9gEg2hjh8XVMeQzTqw4uANfVvvANGdE/JjD+HF6zHVgLRwjg==",
 			"dev": true
 		},
-		"google-closure-compiler-js": {
-			"version": "20200517.0.0",
-			"resolved": "https://registry.npmjs.org/google-closure-compiler-js/-/google-closure-compiler-js-20200517.0.0.tgz",
-			"integrity": "sha512-dz6dOUHx5nhdIqMRXacAYS8aJfLvw4IKxGg28Hq/zeeDPHlX3P3iBK20NgFDfT8zdushThymtMqChSy7C5eyfA==",
-			"dev": true
+		"google-closure-compiler-linux": {
+			"version": "20210808.0.0",
+			"resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20210808.0.0.tgz",
+			"integrity": "sha512-byKi5ITUiWRvEIcQo76i1siVnOwrTmG+GNcBG4cJ7x8IE6+4ki9rG5pUe4+DOYHkfk52XU6XHt9aAAgCcFDKpg==",
+			"dev": true,
+			"optional": true
 		},
 		"google-closure-compiler-osx": {
-			"version": "20200517.0.0",
-			"resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20200517.0.0.tgz",
-			"integrity": "sha512-FWIcsKqLllLjdOBZd7azijVaObydgRd0obVNi63eUfC5MX6T4qxKumGCyor2UCNY6by2ESz+PlGqCFzFhZ6b2g==",
+			"version": "20210808.0.0",
+			"resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20210808.0.0.tgz",
+			"integrity": "sha512-iwyAY6dGj1FrrBdmfwKXkjtTGJnqe8F+9WZbfXxiBjkWLtIsJt2dD1+q7g/sw3w8mdHrGQAdxtDZP/usMwj/Rg==",
+			"dev": true,
+			"optional": true
+		},
+		"google-closure-compiler-windows": {
+			"version": "20210808.0.0",
+			"resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20210808.0.0.tgz",
+			"integrity": "sha512-VI+UUYwtGWDYwpiixrWRD8EklHgl6PMbiEaHxQSrQbH8PDXytwaOKqmsaH2lWYd5Y/BOZie2MzjY7F5JI69q1w==",
 			"dev": true,
 			"optional": true
 		},
@@ -32638,9 +32548,9 @@
 			}
 		},
 		"immutable": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
-			"integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA=="
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
+			"integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw=="
 		},
 		"import-cwd": {
 			"version": "3.0.0",
@@ -36866,7 +36776,8 @@
 		"picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true
 		},
 		"pify": {
 			"version": "4.0.1",
@@ -39927,114 +39838,27 @@
 			}
 		},
 		"sass": {
-			"version": "1.69.0",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.69.0.tgz",
-			"integrity": "sha512-l3bbFpfTOGgQZCLU/gvm1lbsQ5mC/WnLz3djL2v4WCJBDrWm58PO+jgngcGRNnKUh6wSsdm50YaovTqskZ0xDQ==",
+			"version": "1.79.4",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.79.4.tgz",
+			"integrity": "sha512-K0QDSNPXgyqO4GZq2HO5Q70TLxTH6cIT59RdoCHMivrC8rqzaTw5ab9prjz9KUN1El4FLXrBXJhik61JR4HcGg==",
 			"requires": {
-				"chokidar": ">=3.0.0 <4.0.0",
+				"chokidar": "^4.0.0",
 				"immutable": "^4.0.0",
 				"source-map-js": ">=0.6.2 <2.0.0"
 			},
 			"dependencies": {
-				"anymatch": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-					"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-					"requires": {
-						"normalize-path": "^3.0.0",
-						"picomatch": "^2.0.4"
-					}
-				},
-				"binary-extensions": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-					"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
-				},
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"requires": {
-						"fill-range": "^7.0.1"
-					}
-				},
 				"chokidar": {
-					"version": "3.5.3",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-					"integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+					"integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
 					"requires": {
-						"anymatch": "~3.1.2",
-						"braces": "~3.0.2",
-						"fsevents": "~2.3.2",
-						"glob-parent": "~5.1.2",
-						"is-binary-path": "~2.1.0",
-						"is-glob": "~4.0.1",
-						"normalize-path": "~3.0.0",
-						"readdirp": "~3.6.0"
+						"readdirp": "^4.0.1"
 					}
-				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
-				"glob-parent": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-					"requires": {
-						"is-glob": "^4.0.1"
-					}
-				},
-				"is-binary-path": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-					"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-					"requires": {
-						"binary-extensions": "^2.0.0"
-					}
-				},
-				"is-extglob": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
-				},
-				"is-glob": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-					"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-					"requires": {
-						"is-extglob": "^2.1.1"
-					}
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-				},
-				"normalize-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
 				},
 				"readdirp": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-					"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-					"requires": {
-						"picomatch": "^2.2.1"
-					}
-				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"requires": {
-						"is-number": "^7.0.0"
-					}
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
+					"integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA=="
 				}
 			}
 		},
@@ -40376,9 +40200,9 @@
 			"dev": true
 		},
 		"source-map-js": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
 		},
 		"source-map-resolve": {
 			"version": "0.5.2",
@@ -41496,9 +41320,9 @@
 			}
 		},
 		"vinyl": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-			"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
+			"integrity": "sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==",
 			"dev": true,
 			"requires": {
 				"clone": "^2.1.1",
@@ -41512,7 +41336,7 @@
 		"vinyl-sourcemaps-apply": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
-			"integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+			"integrity": "sha512-+oDh3KYZBoZC8hfocrbrxbLUeaYtQK7J5WU5Br9VqWqmCll3tFJqKp97GC9GmMsVIL0qnx2DgEDVxdo5EZ5sSw==",
 			"dev": true,
 			"requires": {
 				"source-map": "^0.5.1"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Jason Johnston <jason@lojjic.com>",
   "license": "MIT",
   "devDependencies": {
-    "@ampproject/rollup-plugin-closure-compiler": "^0.26.0",
+    "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
     "@babel/core": "^7.12.16",
     "@babel/preset-env": "^7.12.16",
     "@babel/preset-react": "^7.12.13",

--- a/packages/troika-three-text/src/Text.js
+++ b/packages/troika-three-text/src/Text.js
@@ -211,10 +211,9 @@ class Text extends Mesh {
 
     /**
      * @member {boolean} textAlignToBox
-     * Whether or not `textAlign` should align to the `maxWidth` of the box. If false, `textAlign` 
-     * aligns to the maximum line width
+     * Whether or not `textAlign` should align to the `maxWidth` of the box, as long as `maxWidth`
+     * is not set to `Infinity`. If false, `textAlign` aligns to the maximum line width.
      */
-
     this.textAlignToBox = false
 
     /**

--- a/packages/troika-three-text/src/Text.js
+++ b/packages/troika-three-text/src/Text.js
@@ -404,7 +404,8 @@ class Text extends Mesh {
     /**
      * @member {boolean} useMaxWidthAsBounds
      * When `true`, `blockBounds` will use the `maxWidth` as the `maxX` instead of the maximum
-     * line width. Defaults to false.
+     * line width. This allows single-line text alignment, and for text to align to the 
+     * extent of the box. Defaults to false.
      */
     this.useMaxWidthAsBounds = false
 

--- a/packages/troika-three-text/src/Text.js
+++ b/packages/troika-three-text/src/Text.js
@@ -65,6 +65,7 @@ const SYNCABLE_PROPS = [
   'text',
   'direction',
   'textAlign',
+  'textAlignToBox',
   'textIndent',
   'whiteSpace',
   'anchorX',
@@ -207,6 +208,14 @@ class Text extends Mesh {
      * The horizontal alignment of each line of text within the overall text bounding box.
      */
     this.textAlign = 'left'
+
+    /**
+     * @member {boolean} textAlignToBox
+     * Whether or not `textAlign` should align to the `maxWidth` of the box. If false, `textAlign` 
+     * aligns to the maximum line width
+     */
+
+    this.textAlignToBox = false
 
     /**
      * @member {number} textIndent
@@ -431,6 +440,7 @@ class Text extends Mesh {
           maxWidth: this.maxWidth,
           direction: this.direction || 'auto',
           textAlign: this.textAlign,
+          textAlignToBox: this.textAlignToBox,
           textIndent: this.textIndent,
           whiteSpace: this.whiteSpace,
           overflowWrap: this.overflowWrap,

--- a/packages/troika-three-text/src/Typesetter.js
+++ b/packages/troika-three-text/src/Typesetter.js
@@ -19,6 +19,7 @@
  * @property {number} [maxWidth]
  * @property {'ltr'|'rtl'} [direction='ltr']
  * @property {string} [textAlign='left']
+ * @property {boolean} [textAlignToBox=false]
  * @property {number} [textIndent=0]
  * @property {'normal'|'nowrap'} [whiteSpace='normal']
  * @property {'normal'|'break-word'} [overflowWrap='normal']
@@ -154,6 +155,7 @@ export function createTypesetter(resolveFonts, bidi) {
       maxWidth=INF,
       direction,
       textAlign='left',
+      textAlignToBox=false,
       textIndent=0,
       whiteSpace='normal',
       overflowWrap='normal',
@@ -432,10 +434,13 @@ export function createTypesetter(resolveFonts, bidi) {
             // Apply horizontal alignment adjustments
             let lineXOffset = 0
             let justifyAdjust = 0
+
+            const widthToAlign = textAlignToBox ? maxWidth : maxLineWidth
+
             if (textAlign === 'center') {
-              lineXOffset = (maxLineWidth - lineWidth) / 2
+              lineXOffset = (widthToAlign - lineWidth) / 2
             } else if (textAlign === 'right') {
-              lineXOffset = maxLineWidth - lineWidth
+              lineXOffset = widthToAlign - lineWidth
             } else if (textAlign === 'justify' && line.isSoftWrapped) {
               // count non-trailing whitespace characters, and we'll adjust the offsets per character in the next loop
               let whitespaceCount = 0
@@ -444,7 +449,7 @@ export function createTypesetter(resolveFonts, bidi) {
                   whitespaceCount++
                 }
               }
-              justifyAdjust = (maxLineWidth - lineWidth) / whitespaceCount
+              justifyAdjust = (widthToAlign - lineWidth) / whitespaceCount
             }
             if (justifyAdjust || lineXOffset) {
               let justifyOffset = 0

--- a/packages/troika-three-text/src/Typesetter.js
+++ b/packages/troika-three-text/src/Typesetter.js
@@ -435,7 +435,7 @@ export function createTypesetter(resolveFonts, bidi) {
             let lineXOffset = 0
             let justifyAdjust = 0
 
-            const widthToAlign = textAlignToBox ? maxWidth : maxLineWidth
+            const widthToAlign = textAlignToBox && maxWidth !== Infinity ? maxWidth : maxLineWidth
 
             if (textAlign === 'center') {
               lineXOffset = (widthToAlign - lineWidth) / 2

--- a/packages/troika-three-text/src/Typesetter.js
+++ b/packages/troika-three-text/src/Typesetter.js
@@ -19,7 +19,7 @@
  * @property {number} [maxWidth]
  * @property {'ltr'|'rtl'} [direction='ltr']
  * @property {string} [textAlign='left']
- * @property {boolean} [textAlignToBox=false]
+ * @property {boolean} [useMaxWidthAsBounds=false]
  * @property {number} [textIndent=0]
  * @property {'normal'|'nowrap'} [whiteSpace='normal']
  * @property {'normal'|'break-word'} [overflowWrap='normal']
@@ -155,7 +155,7 @@ export function createTypesetter(resolveFonts, bidi) {
       maxWidth=INF,
       direction,
       textAlign='left',
-      textAlignToBox=false,
+      useMaxWidthAsBounds=false,
       textIndent=0,
       whiteSpace='normal',
       overflowWrap='normal',
@@ -435,7 +435,7 @@ export function createTypesetter(resolveFonts, bidi) {
             let lineXOffset = 0
             let justifyAdjust = 0
 
-            const widthToAlign = textAlignToBox && maxWidth !== Infinity ? maxWidth : maxLineWidth
+            const widthToAlign = useMaxWidthAsBounds && maxWidth !== Infinity ? maxWidth : maxLineWidth
 
             if (textAlign === 'center') {
               lineXOffset = (widthToAlign - lineWidth) / 2
@@ -635,7 +635,7 @@ export function createTypesetter(resolveFonts, bidi) {
         blockBounds: [ //bounds for the whole block of text, including vertical padding for lineHeight
           anchorXOffset,
           anchorYOffset - totalHeight,
-          anchorXOffset + maxLineWidth,
+          (useMaxWidthAsBounds && maxWidth !== Infinity) ? maxWidth : anchorXOffset + maxLineWidth,
           anchorYOffset
         ],
         visibleBounds, //total bounds of visible text paths, may be larger or smaller than blockBounds


### PR DESCRIPTION
adds new `useMaxWidthAsBounds` & `raycastVisibleBounds` params


```ts
   /**
     * @member {boolean} useMaxWidthAsBounds
     * When `true`, `blockBounds` will use the `maxWidth` as the `maxX` instead of the maximum
     * line width. Defaults to false.
     */
    this.useMaxWidthAsBounds = false

    /**
     * @member {boolean} raycastVisibleBounds
     * When `true`, raycasting will raycast against the visible bounds. Otherwise, will use the 
     * block bounds. Defaults to false.
     */
    this.raycastVisibleBounds = false
```

also upgrades `@ampproject/rollup-plugin-closure-compiler` to `0.27.0` as the project would not build on my system without doing that.